### PR TITLE
feat: add auth guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,55 @@ A repository is where your project work happens--think of it as your project fol
 ### Cloning 
 
 When a repository is created with GitHub, it’s stored remotely in the ☁️. You can clone a repository to create a local copy on your computer and then use Git to sync the two. This makes it easier to fix issues, add or remove files, and push larger commits. You can also use the editing tool of your choice as opposed to the GitHub UI. Cloning a repository also pulls down all the repository data that GitHub has at that point in time, including all versions of every file and folder for the project! This can be helpful if you experiment with your project and then realize you liked a previous version more. 
-To learn more about cloning, read ["Cloning a Repository"](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository). 
+To learn more about cloning, read ["Cloning a Repository"](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository).
+
+---
+
+In order for you to clone or push stuff you need to be authenticated. Unfortunately HTTPS authentication (which was easy but insecure) is depreciated, so we should authenticate with SSH keys instead.
+
+This is on an Ubuntu Terminal btw, but there should be equivalent steps in Windows CMD.
+
+#### Making an SSH key
+```console
+test@TEST:~$ ssh-keygen -t ed25519 -C "your_email@example.com"
+Generating public/private ed25519 key pair.
+Enter file in which to save the key (/home/aikiro42/.ssh/id_ed25519): my_key
+Enter passphrase (empty for no passphrase):
+Enter same passphrase again:
+Your identification has been saved in my_key
+Your public key has been saved in my_key.pub
+The key fingerprint is:
+SHA256:bH/???????????????????????????????????????? your_email@example.com
+The key's randomart image is:
++--[ED25519 256]--+
+|     *******     |
+|   .ooooo.***SS  |
+|  O       O**SSE |
+|   .ooooo.***SSE |
+|   **********E   |
+|   **+   ****    |
+|   +++++++++++   |
+|     amogus      |
+|                 |
++----[SHA256]-----+
+test@TEST:~$
+```
+#### Adding the SSH key to Github
+```console
+test@TEST:~$ cat my_key.pub
+ssh-ed25519 ???????????????????????????????/???????/???????????????????????????? your_email@example.com
+```
+Copypasta `ssh-ed25519 ???????????????????????????????/???????/???????????????????????????? your_email@example.com` when adding an SSH key to your github account.
+
+#### Using the SSH Key
+```console
+test@TEST:~$ eval `ssh-agent -s`
+test@TEST:~$ ssh-add my_key
+```
+Make sure the argued path to the files `my_key` and `my_key.pub` are correct when running `ssh-add`. Yes, the first file has no file extension.
+In the case of `test@TEST:~$ ssh-add my_key`, make sure these two files are in the same directory wherein you're running the command.
+
+---
 
 ### Committing and pushing
 **Committing** and **pushing** are how you can add the changes you made on your local machine to the remote repository in GitHub. That way your instructor and/or teammates can see your latest work when you’re ready to share it. You can make a commit when you have made changes to your project that you want to “checkpoint.” You can also add a helpful **commit message** to remind yourself or your teammates what work you did (e.g. “Added a README with information about our project”).


### PR DESCRIPTION
- Add notes on Github SSH authentication, based on the instructions from the primer lab exercises in CS 140.
- Removed newline at end of `README.md`. (Should it be there? Does it matter?)